### PR TITLE
Prevent some things from being rendered as water

### DIFF
--- a/shaders/lib/iPBR/iPBR.glsl
+++ b/shaders/lib/iPBR/iPBR.glsl
@@ -242,17 +242,21 @@ float generateEmission(PBRData data, float lumaThreshold, float satThreshold){
       data.SSS = oldData.SSS;
     #endif
 
+    #ifdef gbuffers_water
     if(int(ID + 0.5) == IPBR_WATER){
         data.perceptualSmoothness = 1.0;
         data.baseReflectance = 0.02;
     }
+    #endif
 
     if(!hasRPPorosity) data.porosity = 0.2;
 
+    #ifdef gbuffers_water
     if (data.porosity > 0 && int(ID + 0.5) != IPBR_WATER){
 			data.baseReflectance = mix(data.baseReflectance, 0.02, (1.0 - data.porosity) * biomeWetness * smoothstep(13.5 / 15.0, 14.5 / 15.0, vertLightmap.y));
 			data.perceptualSmoothness = mix(data.perceptualSmoothness, (1.0 - data.porosity), biomeWetness * smoothstep(13.5 / 15.0, 14.5 / 15.0, vertLightmap.y));
 		}
+    #endif
 
     if(IPBR_EMITS_LIGHT(ID))   applyiPBR(data.emission, generateEmission(data, 0.8, 0.6));
 

--- a/shaders/program/gbuffers_main.glsl
+++ b/shaders/program/gbuffers_main.glsl
@@ -239,9 +239,12 @@ float LOD;
 
 vec4 GetDiffuse(vec2 coord, float materialIDs) {
     vec4 diffuse;
+
+    #ifdef gbuffers_water
     if (materialIDs == 1) { // water
         return vec4(0.0);
     }
+    #endif
 
 
 

--- a/shaders/program/gbuffers_shadow.glsl
+++ b/shaders/program/gbuffers_shadow.glsl
@@ -229,6 +229,7 @@ void main() {
 
 	vec4 diffuse = color * texture(gtexture, texcoord);
 
+	#ifdef gbuffers_water
 	if (materialIDs == IPBR_WATER) {
 		diffuse = vec4(mix(WATER_COLOR.rgb, color.rgb, BIOME_WATER_TINT), WATER_COLOR.a);
 		#ifdef WATER_CAUSTICS
@@ -239,6 +240,7 @@ void main() {
 			diffuse.a = pow2(diffuse.a);
 		#endif
 	}
+	#endif
 	
 	gl_FragData[0] = diffuse;
 	gl_FragData[1] = vec4(vertNormal.xy * 0.5 + 0.5, 0.0, 1.0);


### PR DESCRIPTION
For me, this fixes blocks in their item/entity form on a conveyor belt (Create) and in a casting basin/table (Tinker's Construct) from being rendered incorrectly